### PR TITLE
Automatically run the cluster tests with Arquillian custom containers; u...

### DIFF
--- a/cluster-tests/pom.xml
+++ b/cluster-tests/pom.xml
@@ -27,16 +27,24 @@
             <artifactId>jboss-servlet-api_3.0_spec</artifactId>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>
         </dependency>
 
+
         <dependency>
             <groupId>org.jboss.as</groupId>
             <artifactId>jboss-as-arquillian-container-remote</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.jboss.as</groupId>
+            <artifactId>jboss-as-arquillian-container-managed</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -67,15 +75,15 @@
         </dependency>
 
         <dependency>
-           	<groupId>org.infinispan</groupId>
-           	<artifactId>infinispan-core</artifactId>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>javax.enterprise</groupId>
-        	   <artifactId>cdi-api</artifactId>
-        	   <scope>test</scope>
+            <artifactId>cdi-api</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- MapReduce libs -->
@@ -129,7 +137,7 @@
         <profile>
             <id>cluster</id>
             <activation>
-                <activeByDefault>false</activeByDefault>
+                <activeByDefault>true</activeByDefault>
                 <property>
                     <name>cluster</name>
                 </property>
@@ -139,10 +147,86 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.10</version>
-                        <configuration>
-                            <skipTests>false</skipTests>
-                        </configuration>
+                        <version>2.13</version>
+
+                        <executions combine.children="append">
+
+                            <execution>
+                                <id>capedward.test.start</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+
+                                <configuration>
+                                    <!-- Never fork this process for the containers to keep running -->
+                                    <forkMode>never</forkMode>
+                                    <skipTests>false</skipTests>
+                                    <!--<groups>org.jboss.test.capedwarf.common.support.JBoss</groups>-->
+
+                                    <includes>
+                                        <include>org/jboss/test/capedwarf/cluster/setup/**/*Start.java</include>
+                                    </includes>
+                                    <systemPropertyVariables>
+                                        <arquillian.launch>jboss-cluster-setup</arquillian.launch>
+                                        <capedwarf.dist>${env.JBOSS_HOME}</capedwarf.dist>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExcludes>org.jboss.as:jboss-as-arquillian-container-remote</classpathDependencyExcludes>
+                                    </classpathDependencyExcludes>
+
+                                    <!-- Not to mixup logs -->
+                                    <reportNameSuffix>start</reportNameSuffix>
+                                </configuration>
+                            </execution>
+
+                            <!-- Actual test execution -->
+                            <execution>
+                                <id>capedward.test.execute</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <skipTests>false</skipTests>
+                                    <groups>org.jboss.test.capedwarf.common.support.JBoss</groups>
+                                    <includes>
+                                        <include>org/jboss/test/capedwarf/cluster/test/**/*Test.java</include>
+                                    </includes>
+                                    <systemPropertyVariables>
+                                        <arquillian.launch>jboss-cluster</arquillian.launch>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExcludes>org.jboss.as:jboss-as-arquillian-container-managed</classpathDependencyExcludes>
+                                    </classpathDependencyExcludes>
+                                    <reportNameSuffix>execute</reportNameSuffix>
+                                </configuration>
+                            </execution>
+
+                             <execution>
+                                <id>capedward.test.stop</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <forkMode>never</forkMode>
+                                    <skipTests>false</skipTests>
+                                    <includes>
+                                        <include>org/jboss/test/capedwarf/cluster/setup/**/*Stop.java</include>
+                                    </includes>
+                                    <systemPropertyVariables>
+                                        <arquillian.launch>jboss-cluster-setup</arquillian.launch>
+                                        <capedwarf.dist>${env.JBOSS_HOME}</capedwarf.dist>
+                                    </systemPropertyVariables>
+                                    <classpathDependencyExcludes>
+                                        <classpathDependencyExcludes>org.jboss.as:jboss-as-arquillian-container-remote</classpathDependencyExcludes>
+                                    </classpathDependencyExcludes>
+                                    <reportNameSuffix>stop</reportNameSuffix>
+                                </configuration>
+                            </execution>
+
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/cluster-tests/src/test/java/org/jboss/test/capedwarf/cluster/setup/JBossContainerStart.java
+++ b/cluster-tests/src/test/java/org/jboss/test/capedwarf/cluster/setup/JBossContainerStart.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.test.capedwarf.cluster.setup;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.test.capedwarf.common.support.JBoss;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Ensure the containers are running, otherwise start them at the beginning of testsuite.
+ *
+ * @author Radoslav Husar
+ * @since Jun 2013
+ */
+@RunWith(Arquillian.class)
+@Category(JBoss.class)
+public class JBossContainerStart {
+
+    @ArquillianResource
+    private ContainerController controller;
+
+    public static final String CONTAINER_1 = "container-1";
+    public static final String CONTAINER_2 = "container-2";
+
+    @Test
+    @RunAsClient
+    public void testStartContainers() {
+        controller.start(CONTAINER_1);
+        controller.start(CONTAINER_2);
+    }
+}

--- a/cluster-tests/src/test/java/org/jboss/test/capedwarf/cluster/setup/JBossContainerStop.java
+++ b/cluster-tests/src/test/java/org/jboss/test/capedwarf/cluster/setup/JBossContainerStop.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.test.capedwarf.cluster.setup;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.test.capedwarf.common.support.JBoss;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Stop the containers after the tests have run.
+ *
+ * @author Radoslav Husar
+ * @since Jun 2013
+ */
+@RunWith(Arquillian.class)
+@Category(JBoss.class)
+public class JBossContainerStop {
+
+    @ArquillianResource
+    private ContainerController controller;
+
+    public static final String CONTAINER_1 = "container-1";
+    public static final String CONTAINER_2 = "container-2";
+
+    @Test
+    @RunAsClient
+    public void testStartContainers() {
+        controller.stop(CONTAINER_1);
+        controller.stop(CONTAINER_2);
+    }
+}

--- a/cluster-tests/src/test/java/org/jboss/test/capedwarf/cluster/test/infinispan/InfinispanClusterTestBase.java
+++ b/cluster-tests/src/test/java/org/jboss/test/capedwarf/cluster/test/infinispan/InfinispanClusterTestBase.java
@@ -23,8 +23,8 @@ import org.jboss.test.capedwarf.common.test.TestBase;
  */
 public abstract class InfinispanClusterTestBase extends TestBase {
 
-    private final String textFileName = "dummy.txt";
-    private final int numPopularWords = 20;
+    private static final String textFileName = "dummy.txt";
+    private static final int numPopularWords = 20;
 
     protected void wordCount() throws IOException {
         Cache<String, String> cache = getCache();
@@ -50,7 +50,7 @@ public abstract class InfinispanClusterTestBase extends TestBase {
         }
     }
 
-    abstract protected Cache<String, String> getCache();
+    protected abstract Cache<String, String> getCache();
 
     private void loadData(Cache<String, String> cache) throws IOException {
         //

--- a/cluster-tests/src/test/resources/arquillian.launch
+++ b/cluster-tests/src/test/resources/arquillian.launch
@@ -1,1 +1,0 @@
-jboss-cluster

--- a/common/src/test/resources/arquillian.xml
+++ b/common/src/test/resources/arquillian.xml
@@ -31,6 +31,7 @@
         <property name="deploymentExportPath">target/deployments</property>
     </engine -->
 
+    <!-- Group to treat containers as remote but managed deployments -->
     <group qualifier="jboss-cluster" >
 
         <container qualifier="container-1" >
@@ -40,17 +41,45 @@
             </configuration>
         </container>
 
-        <!--
-        node B config:
-         - run with -Djboss.node.name=node-b
-         - use port offset 100
-         -->
         <container qualifier="container-2">
             <configuration>
                 <property name="managementAddress">127.0.0.1</property>
                 <property name="managementPort">10099</property>
             </configuration>
         </container>
+
+    </group>
+
+    <!-- Group to start the containers in custom mode -->
+
+    <group qualifier="jboss-cluster-setup">
+
+        <container qualifier="container-1" mode="custom" managed="true" default="true">
+            <configuration>
+                <property name="jbossHome">${capedwarf.dist}</property>
+                <!-- Do not wrap the following line! -->
+                <property name="javaVmArguments">-Djboss.inst=${capedwarf.dist} -Djboss.node.name=nodeA -Djboss.server.data.dir=${capedwarf.dist}/standalone/dataA -Djboss.server.temp.dir=${capedwarf.dist}/standalone/tmpA -Djboss.server.log.dir=${capedwarf.dist}/standalone/logA -Djboss.server.deploy.dir=${capedwarf.dist}/standalone/contentA</property>
+                <property name="serverConfig">standalone-capedwarf.xml</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">9999</property>
+                <property name="waitForPorts">9999</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="container-2" mode="custom" managed="true">
+            <configuration>
+                <property name="jbossHome">${capedwarf.dist}</property>
+                <!-- Do not wrap the following line! -->
+                <property name="javaVmArguments">-Djboss.inst=${capedwarf.dist} -Djboss.node.name=nodeB -Djboss.server.data.dir=${capedwarf.dist}/standalone/dataB -Djboss.server.temp.dir=${capedwarf.dist}/standalone/tmpB -Djboss.server.log.dir=${capedwarf.dist}/standalone/logB -Djboss.server.deploy.dir=${capedwarf.dist}/standalone/contentB -Djboss.socket.binding.port-offset=100</property>
+                <property name="serverConfig">standalone-capedwarf.xml</property>
+                <property name="managementAddress">127.0.0.1</property>
+                <property name="managementPort">10099</property>
+                <property name="waitForPorts">10099</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
     </group>
 
 </arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -770,6 +770,13 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss.as</groupId>
+                <artifactId>jboss-as-arquillian-container-managed</artifactId>
+                <version>${version.jboss.as7}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jboss.xnio</groupId>
                 <artifactId>xnio-api</artifactId>
                 <version>${version.org.jboss.xnio}</version>
@@ -963,6 +970,22 @@
                 <dependency>
                     <groupId>org.jboss.as</groupId>
                     <artifactId>jboss-as-arquillian-container-remote</artifactId>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.jboss.xnio</groupId>
+                            <artifactId>xnio-api</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.jboss.xnio</groupId>
+                            <artifactId>xnio-nio</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-arquillian-container-managed</artifactId>
                     <scope>test</scope>
                     <exclusions>
                         <exclusion>


### PR DESCRIPTION
...sing JBOSS_HOME for CapeDwarf distribution

Hi @alesj here is a suturday gift for you. 

This is the idea behind how to make the clustering tests automated.

There are 3 executions: first execution started the servers, second one runs the test (as was until now) and the 3rd one stops the servers.

This is one approach that leverages the 'hack' you have been using until now -- having deployments managed. If we were to make this differently, we would either need to make deployments unmanaged and thus having to deploy via deployer API (because custom containers do not support managed deployments) or we would have to stop and start the container after every test (with manual mode) which is also mostyl undesirable.

Give it a try and let me know ;-)
